### PR TITLE
Allow to check whether an entity action is enabled or not

### DIFF
--- a/src/Controller/Component/EntityActionComponent.php
+++ b/src/Controller/Component/EntityActionComponent.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace EntityActions\Controller\Component;
+
+use Cake\Controller\Component;
+use Cake\Datasource\EntityInterface;
+use Cake\ORM\Query;
+use EntityActions\Exception\ActionNotEnabledException;
+use EntityActions\Manager\EntityActionManager;
+
+/**
+ * Component for common entity action controler logic.
+ */
+class EntityActionComponent extends Component
+{
+    /**
+     * Checks whether the provided entity action is enabled for the entity returned by the provided query.
+     * This method calls Query::firstOrFail() on the provided query to retrieve the entity in question.
+     * @param Cake\ORM\Query $entityQuery The query to use to retrieve the entity.
+     * @param string $entityActionClass The IEntityAction class to check for enabled.
+     * @return Cake\Datasource\EntityInterface Returns the retrieved entity.
+     * @throws ActionNotEnabledException This exception is thrown in case the entity action is not enabled for the retrieved entity.
+     */
+    function checkEnabledOrThrow(Query $entityQuery, string $entityActionClass): EntityInterface
+    {
+        $entity = $entityQuery->find('entityActions', ['entityAction' => $entityActionClass])->firstOrFail();
+        $entityAction = EntityActionManager::getEntityAction($entity, $entityActionClass);
+        if ($entityAction->isEnabled($entity)) {
+            return $entity;
+        }
+        throw new ActionNotEnabledException();
+    }
+}

--- a/src/EntityAction/EntityAction.php
+++ b/src/EntityAction/EntityAction.php
@@ -79,6 +79,15 @@ class EntityAction implements IEntityAction {
         return $enabled($entity);
     }
 
+    /**
+     * Returns associations that are required for authorized/enabled calculations for this entity action.
+     * @return array An array or required associations.
+     */
+    public function getAssociations(): array
+    {
+        return [];
+    }
+
     public function getViewHints() : array {
         return [];
     }

--- a/src/EntityAction/IEntityAction.php
+++ b/src/EntityAction/IEntityAction.php
@@ -49,5 +49,7 @@ interface IEntityAction {
      */
     public function isEnabled(Entity $entity);
 
+    public function getAssociations(): array;
+
     public function getViewHints() : array;
 }

--- a/src/Exception/ActionNotEnabledException.php
+++ b/src/Exception/ActionNotEnabledException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace EntityActions\Exception;
+
+use Cake\Http\Exception\BadRequestException;
+
+/**
+ * This exception is thrown, when an entity action is not enabled when checked inside a controller method.
+ */
+class ActionNotEnabledException extends BadRequestException
+{
+    public function __construct()
+    {
+        parent::__construct(__('Diese Aktion ist zur Zeit nicht verfügbar.'));
+    }
+}

--- a/src/Exception/UnknownEntityActionException.php
+++ b/src/Exception/UnknownEntityActionException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace EntityActions\Exception;
+
+use Cake\Core\Exception\Exception;
+
+class UnknownEntityActionException extends Exception
+{
+    public function __construct(string $entityClass, string $entityActionClass)
+    {
+        parent::__construct(sprintf('Entity Action "%s" not registered for entity class "%s".', $entityActionClass, $entityClass));
+    }
+}

--- a/src/Manager/EntityActionManager.php
+++ b/src/Manager/EntityActionManager.php
@@ -3,7 +3,7 @@ namespace EntityActions\Manager;
 
 use Cake\Collection\Collection;
 use Cake\Core\App;
-
+use EntityActions\EntityAction\IEntityAction;
 use EntityActions\Exception\MissingEntityActionRegistryException;
 use EntityActions\Exception\NotAnEntityException;
 
@@ -52,18 +52,19 @@ class EntityActionManager {
      * @throws NotAnEntityException
      *          This exception is thrown when the provided argument is neither an entity object nor the name of an entity class.
      */
-    public static function get($entityClass) {
+    public static function get($entityClass): Collection
+    {
         if (static::$entityActionRegistry == null) {
             throw new MissingEntityActionRegistryException('No entity action registry provided prior to accessing the entity action manager.');
         }
         return static::$entityActionRegistry->getEntityActions($entityClass);
     }
 
-    public static function getEntityAction($entityClass, $entityActionClass) {
+    public static function getEntityAction($entityClass, $entityActionClass): ?IEntityAction
+    {
         $entityActions = static::get($entityClass);
         return $entityActions->filter(function ($entityAction) use ($entityActionClass) {
             return get_class($entityAction) == $entityActionClass;
         })->first();
     }
-
 }

--- a/src/Manager/EntityActionRegistry.php
+++ b/src/Manager/EntityActionRegistry.php
@@ -2,7 +2,7 @@
 namespace EntityActions\Manager;
 
 use Cake\Collection\Collection;
-
+use Cake\ORM\Entity;
 use EntityActions\Exception\NotAnEntityException;
 
 /**
@@ -15,7 +15,7 @@ abstract class EntityActionRegistry implements IEntityActionRegistry {
     private $entityActions;
 
     public function getEntityActions($entityClass) {
-        if (is_a($entityClass, 'Cake\ORM\Entity')) {
+        if (is_a($entityClass, Entity::class)) {
             $entityClass = get_class($entityClass);
         }
         if (!is_string($entityClass)) {

--- a/src/Model/Behavior/EntityActionBehavior.php
+++ b/src/Model/Behavior/EntityActionBehavior.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace EntityActions\Model\Behavior;
+
+use Cake\Collection\Collection;
+use Cake\ORM\Behavior;
+use Cake\ORM\Query;
+use EntityActions\EntityAction\IEntityAction;
+use EntityActions\Exception\UnknownEntityActionException;
+use EntityActions\Manager\EntityActionManager;
+
+/**
+ * Behavior for common entity action table logic.
+ */
+class EntityActionBehavior extends Behavior
+{
+    /**
+     * This finder adds associations to the provided query based on the entity actions associated with the entity class belonging to the table.
+     *
+     * @param Cake\ORM\Query $query The query to adapt.
+     * @param array $options
+     *   `entityAction`: Allows to restrict the entity actions considered to a specific one instead of all the entity actions of the respective
+     *                   entity.
+     * @return Cake\ORM\Query Returns the modified query.
+     */
+    public function findEntityActions(Query $query, array $options)
+    {
+        $table = $this->getTable();
+        $entityClass = $table->getEntityClass();
+        if (isset($options['entityAction'])) {
+            $entityActionClass = $options['entityAction'];
+            $entityAction = EntityActionManager::getEntityAction($entityClass, $entityActionClass);
+            if (!$entityAction) {
+                throw new UnknownEntityActionException($entityClass, $entityActionClass);
+            }
+            $entityActions = new Collection([$entityAction]);
+        } else {
+            $entityActions = EntityActionManager::get($entityClass);
+        }
+
+        $associations = $entityActions
+            ->map(function (IEntityAction $entityAction) {
+                return $entityAction->getAssociations();
+            })
+            ->reduce(function ($accumulated, $associations) {
+                return $accumulated + $associations;
+            }, []);
+
+        if (!empty($associations)) {
+            $query->contain($associations);
+        }
+
+        return $query;
+    }
+}


### PR DESCRIPTION
Previously, checking for entity action enablement in the respective controller method was not directly supported by this plugin.
This change adds a new component that provides a method to do exactly that. In addition, a behavior was added providing a finder that adds associations required by all or a specific entity action of the tables entity to the query.